### PR TITLE
Adding placements information

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -158,6 +158,16 @@ main p {
   margin: 0 0 20px 0;
 }
 
+main code {
+  background-color: #818b981f;
+  padding: 0.2em;
+  font-size: inherit;
+  border-radius: 6px;
+  margin: 0; 
+  white-space: break-spaces;
+
+}
+
 main li {
   font-size: 1.1875rem;
   color: var(--night);
@@ -274,12 +284,15 @@ footer {
 
 /* Tables in main */
 main table {
-  border: 0px solid
+  border: 0px solid;
+  margin-bottom: 1.1875rem;
+  min-width: 100%;
 }
 
 main th, main td {
   text-align: left;
   padding: 5px;
+  max-width: 250px;
 }
 
 main th {
@@ -292,10 +305,12 @@ main td {
 
 main td code {
   font-size: 1.25em;
+  padding: 0.2em 0.4em;
+  line-height: 1.75em;
 }
 
 main tr:nth-child(even) {
-  background-color: var(--white-smoke);
+  background-color: rgba(243, 242, 241, 0.5);
 }
 
 main table.catalogue td {
@@ -304,6 +319,7 @@ main table.catalogue td {
 
 main table.catalogue td a.web-button{
     margin: 10px;
+    width: 140px; /* this is hard-coded, which is obviously bad, but the only way I could keep buttons of consistent width */
 }
 
 /* Footer */

--- a/spec/index.html
+++ b/spec/index.html
@@ -48,10 +48,17 @@
                 <th>Issues</th>
             </tr>
             <tr>
-                <td>Person Data Standard (Identification)</th>
-                <td>Draft</th>
-                <td><a href="/spec/person" class="web-button">Person Specifications</a></td>
+                <td>Person Data Standard (Identification)</td>
+                <td>Draft</td>
+                <td><a href="/spec/person" class="web-button">Person Specification</a></td>
                 <td><a href="https://github.com/SocialCareData/person-standard/issues" class="web-button" target="_blank">Issues</a>
+                </td>
+            </tr>
+            <tr>
+                <td>Placements Data Standard</td>
+                <td>Draft</td>
+                <td><a href="/spec/placements" class="web-button">Placements Specification</a></td>
+                <td><a href="https://github.com/SocialCareData/placements-standard/issues" class="web-button" target="_blank">Issues</a>
                 </td>
             </tr>
         </table>

--- a/spec/placements/index.html
+++ b/spec/placements/index.html
@@ -33,10 +33,10 @@
     <!-- Header End -->
    <main>
         <div class="spec-content">
-            <div id="spec-about" class="markdown-content-external" data-markdown="https://raw.githubusercontent.com/SocialCareData/placements-standard/refs/heads/main/README.md">
+            <div id="spec-about" class="markdown-content-external" data-markdown="https://raw.githubusercontent.com/SocialCareData/placements-standard/refs/heads/ivjyot-oberoi-patch-1/README.md">
                     <!-- spec Markdown content loaded here -->
                 </div>
-            <div id="spec-text" class="markdown-content-external" data-markdown="https://raw.githubusercontent.com/SocialCareData/placements-standard/refs/heads/main/specification.md">
+            <div id="spec-text" class="markdown-content-external" data-markdown="https://raw.githubusercontent.com/SocialCareData/placements-standard/refs/heads/ivjyot-oberoi-patch-1/specification.md">
                     <!-- spec Markdown content loaded here -->
                 </div>
 

--- a/spec/placements/index.html
+++ b/spec/placements/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/png" href="/images/logos/main_logo.png" sizes="32x32">
+  <title>Specification - Data Standards for Social Care</title>
+  <meta name="description" content="Metadata spec for the Data Standards for Social Care programme">
+  <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body>
+  <!-- Header Start -->
+    <header>
+        <div class="header-top">
+            <h4>ALPHA - This website is currently under development. Please provide feedback on <a href="https://github.com/SocialCareData/SocialCareData.github.io/issues/new?title=Alpha+Website+Feedback" target="_blank">Github</a></h3>
+        </div>
+        <div class="site-header">
+            <div class="header-left">
+                <h1 class="landing-site-title"><a href="/" id="index-page-button">Data Standards for Social Care</a>
+                </h1>
+            </div>
+            <div class="header-right">
+                <nav class="nav-menu">
+                    <ul>
+                        <li><a href="/use-cases">Use Cases</a></li>
+                        <li><a href="/spec">Specifications</a></li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </header>
+    <!-- Header End -->
+   <main>
+        <div class="spec-content">
+            <div id="spec-about" class="markdown-content-external" data-markdown="https://raw.githubusercontent.com/SocialCareData/placements-standard/refs/heads/main/README.md">
+                    <!-- spec Markdown content loaded here -->
+                </div>
+            <div id="spec-text" class="markdown-content-external" data-markdown="https://raw.githubusercontent.com/SocialCareData/placements-standard/refs/heads/main/specification.md">
+                    <!-- spec Markdown content loaded here -->
+                </div>
+
+            <!-- <pre id="spec-diagram" class="mermaid" data-markdown="https://raw.githubusercontent.com/SocialCareData/placements-standard/refs/heads/main/datamodel.md"></pre> -->
+
+        </div>
+   </main>
+   <footer>
+        <div id="footer-text" class="markdown-content" data-markdown="footer.md">
+                    <!-- footer Markdown content loaded here -->
+                </div>
+   </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script type="module" src="/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
new page and route towards the placement spec. includes the README.md and spec.md. also some better table styling, and code text looks a bit more like code text with some background shadows.

note: table styling could be weird on different screen sizes, should check

todo: figure out where to display background_1.md on the website. should be discussed with the team.

afterwards todo: make sure the tables in the background_1.md content are styled nicely and see if we can shade specific table cells if they contain a tick (would be through js)

stretch: overhaul table styling to look nicer
